### PR TITLE
Fix various issues with requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
---index-url https://download.pytorch.org/whl/cu121
-torch==2.4.1
+torch==2.4.1 --index-url https://download.pytorch.org/whl/cu121
 torchvision==0.19.1
 xformers==0.0.28.post1
-diffusers
+diffusers==0.32.2
 einops
 transformers
 accelerate
@@ -14,3 +13,4 @@ openai
 tenacity
 pyyaml
 gradio
+protobuf


### PR DESCRIPTION
Hey @haokbd 

I have managed to get `app.py` running after the following changes to `requirements.txt`

The reason for pinning diffusers is that https://github.com/huggingface/diffusers/commit/694f9658c1f511e323bf86cd88af0a2e2b0fee9b recently introduced `_optional_components = ["image_encoder", "feature_extractor"]` in `FluxInpaintPipeline`, this code is not compatible with those fields at the moment.

**How to test**
1. `python -m venv venv`
2. `source venv/bin/activate`
3. `pip install -r requirements.txt`
4. `python3 app.py`